### PR TITLE
Add place card modal and suggestion form

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,8 @@ import styled from 'styled-components'
 import { places } from './data/places'
 import { MapView } from './components/MapView'
 import { Sidebar } from './components/Sidebar'
+import { PlaceCard } from './components/PlaceCard'
+import { SuggestModal } from './components/SuggestModal'
 
 const Container = styled.div`
   display: flex;
@@ -12,6 +14,7 @@ const Container = styled.div`
 function App() {
   const [selectedId, setSelectedId] = useState<number | null>(null)
   const [filter, setFilter] = useState('')
+  const [showSuggest, setShowSuggest] = useState(false)
 
   const handleSelect = (id: number) => {
     setSelectedId(id)
@@ -33,10 +36,18 @@ function App() {
         onSelect={handleSelect}
         filter={filter}
         onFilter={setFilter}
+        onSuggest={() => setShowSuggest(true)}
       />
       <div style={{ flex: 1 }}>
         <MapView places={list} selectedId={selectedId} onSelect={handleSelect} />
+        {selectedId && (
+          <PlaceCard
+            place={places.find((p) => p.id === selectedId)!}
+            onClose={() => setSelectedId(null)}
+          />
+        )}
       </div>
+      {showSuggest && <SuggestModal onClose={() => setShowSuggest(false)} />}
     </Container>
   )
 }

--- a/src/components/PlaceCard.tsx
+++ b/src/components/PlaceCard.tsx
@@ -1,0 +1,58 @@
+import styled from 'styled-components'
+import type { Place } from '../data/places'
+
+const Card = styled.div`
+  position: absolute;
+  right: 1rem;
+  top: 1rem;
+  background: #fff;
+  padding: 1rem;
+  width: 240px;
+  border-radius: 8px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
+  z-index: 1000;
+  @media (max-width: 768px) {
+    width: calc(100% - 2rem);
+    left: 1rem;
+    right: 1rem;
+    top: auto;
+    bottom: 1rem;
+  }
+`
+
+const Image = styled.img`
+  width: 100%;
+  height: 120px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+`
+
+const Close = styled.button`
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+`
+
+interface PlaceCardProps {
+  place: Place
+  onClose: () => void
+}
+
+export const PlaceCard: React.FC<PlaceCardProps> = ({ place, onClose }) => {
+  return (
+    <Card>
+      <Close aria-label="Close" onClick={onClose}>&times;</Close>
+      {place.image && <Image src={place.image} alt={place.name} />}
+      <h3>{place.name}</h3>
+      <div>
+        {'\u2605'.repeat(place.rating)}{'\u2606'.repeat(5 - place.rating)} {place.rating}/5
+      </div>
+      <p>{place.review}</p>
+    </Card>
+  )
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -34,15 +34,27 @@ const SearchInput = styled.input`
   margin-bottom: 0.5rem;
 `
 
+const SuggestButton = styled.button`
+  width: 100%;
+  padding: 0.5rem;
+  margin-top: 0.5rem;
+  background: #333;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+  border-radius: 4px;
+`
+
 interface SidebarProps {
   places: Place[]
   selectedId: number | null
   onSelect: (id: number) => void
   filter: string
   onFilter: (val: string) => void
+  onSuggest: () => void
 }
 
-export const Sidebar: React.FC<SidebarProps> = ({ places, selectedId, onSelect, filter, onFilter }) => {
+export const Sidebar: React.FC<SidebarProps> = ({ places, selectedId, onSelect, filter, onFilter, onSuggest }) => {
   const refs = useRef<Record<number, HTMLDivElement | null>>({})
   useEffect(() => {
     if (selectedId && refs.current[selectedId]) {
@@ -83,6 +95,7 @@ export const Sidebar: React.FC<SidebarProps> = ({ places, selectedId, onSelect, 
           <small>{place.review}</small>
         </ListItem>
       ))}
+      <SuggestButton onClick={onSuggest}>Suggest a Spot for Suu</SuggestButton>
     </Wrapper>
   )
 }

--- a/src/components/SuggestModal.tsx
+++ b/src/components/SuggestModal.tsx
@@ -1,0 +1,87 @@
+import styled from 'styled-components'
+import { useState } from 'react'
+
+const Overlay = styled.div`
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+`
+
+const Modal = styled.div`
+  position: relative;
+  background: #fff;
+  padding: 1rem;
+  width: 300px;
+  border-radius: 8px;
+`
+
+const Close = styled.button`
+  position: absolute;
+  top: 0.25rem;
+  right: 0.25rem;
+  background: transparent;
+  border: none;
+  font-size: 1.2rem;
+  cursor: pointer;
+`
+
+interface SuggestModalProps {
+  onClose: () => void
+}
+
+export const SuggestModal: React.FC<SuggestModalProps> = ({ onClose }) => {
+  const [name, setName] = useState('')
+  const [description, setDescription] = useState('')
+  const [image, setImage] = useState('')
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    const suggestions = JSON.parse(localStorage.getItem('suggestions') || '[]')
+    suggestions.push({ name, description, image })
+    localStorage.setItem('suggestions', JSON.stringify(suggestions))
+    setName('')
+    setDescription('')
+    setImage('')
+    onClose()
+  }
+
+  return (
+    <Overlay>
+      <Modal>
+        <Close aria-label="Close" onClick={onClose}>&times;</Close>
+        <h3>Suggest a Spot for Suu</h3>
+        <form onSubmit={handleSubmit}>
+          <input
+            style={{ width: '100%', marginBottom: '0.5rem' }}
+            placeholder="Name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            required
+          />
+          <textarea
+            style={{ width: '100%', marginBottom: '0.5rem' }}
+            placeholder="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <input
+            style={{ width: '100%', marginBottom: '0.5rem' }}
+            placeholder="Image URL (optional)"
+            value={image}
+            onChange={(e) => setImage(e.target.value)}
+          />
+          <button style={{ width: '100%' }} type="submit">
+            Submit
+          </button>
+        </form>
+      </Modal>
+    </Overlay>
+  )
+}

--- a/src/data/places.ts
+++ b/src/data/places.ts
@@ -1,12 +1,13 @@
 export interface Place {
-  id: number;
-  name: string;
-  city: string;
-  country: string;
-  lat: number;
-  lng: number;
-  review: string;
-  rating: number;
+  id: number
+  name: string
+  city: string
+  country: string
+  lat: number
+  lng: number
+  review: string
+  rating: number
+  image?: string
 }
 
 export const places: Place[] = [
@@ -19,6 +20,7 @@ export const places: Place[] = [
     lng: 98.9853,
     review: 'Cozy spot with thin crust perfection.',
     rating: 4,
+    image: 'https://picsum.photos/seed/pizza1/400/300',
   },
   {
     id: 2,
@@ -29,6 +31,7 @@ export const places: Place[] = [
     lng: 126.9780,
     review: 'Creative toppings and great atmosphere.',
     rating: 5,
+    image: 'https://picsum.photos/seed/pizza2/400/300',
   },
   {
     id: 3,
@@ -39,6 +42,7 @@ export const places: Place[] = [
     lng: 14.2681,
     review: 'Authentic Neapolitan pies straight from the oven.',
     rating: 5,
+    image: 'https://picsum.photos/seed/pizza3/400/300',
   },
   {
     id: 4,
@@ -49,6 +53,7 @@ export const places: Place[] = [
     lng: 139.6917,
     review: 'Fusion-style slices with a local twist.',
     rating: 4,
+    image: 'https://picsum.photos/seed/pizza4/400/300',
   },
   {
     id: 5,
@@ -59,6 +64,7 @@ export const places: Place[] = [
     lng: 13.405,
     review: 'Late-night favorite with crispy bases.',
     rating: 3,
+    image: 'https://picsum.photos/seed/pizza5/400/300',
   },
   {
     id: 6,
@@ -69,6 +75,7 @@ export const places: Place[] = [
     lng: -74.006,
     review: 'Classic New York slices done right.',
     rating: 4,
+    image: 'https://picsum.photos/seed/pizza6/400/300',
   },
   {
     id: 7,
@@ -79,6 +86,7 @@ export const places: Place[] = [
     lng: 144.9631,
     review: 'Laid-back spot with rich flavors.',
     rating: 4,
+    image: 'https://picsum.photos/seed/pizza7/400/300',
   },
   {
     id: 8,
@@ -89,6 +97,7 @@ export const places: Place[] = [
     lng: -43.1729,
     review: 'Beachside pizza with tropical vibes.',
     rating: 3,
+    image: 'https://picsum.photos/seed/pizza8/400/300',
   },
   {
     id: 9,
@@ -99,6 +108,7 @@ export const places: Place[] = [
     lng: 2.3522,
     review: 'Charming bistro serving gourmet slices.',
     rating: 5,
+    image: 'https://picsum.photos/seed/pizza9/400/300',
   },
   {
     id: 10,
@@ -109,5 +119,6 @@ export const places: Place[] = [
     lng: -79.3832,
     review: 'Modern take on traditional pizza.',
     rating: 4,
+    image: 'https://picsum.photos/seed/pizza10/400/300',
   },
 ]

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,7 @@
+* {
+  box-sizing: border-box;
+}
+
 body {
   margin: 0;
   font-family: sans-serif;


### PR DESCRIPTION
## Summary
- add optional images to the pizza place data
- create new `PlaceCard` overlay for marker details
- implement `SuggestModal` for suggesting pizza spots
- update sidebar to include suggestion button
- show place card and modal in `App`
- tweak global CSS box-sizing

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_683ff743ad0483268635f132e770b6c7