### PR TITLE
Interactive pizza map UI overhaul

### DIFF
--- a/src/components/MapView.tsx
+++ b/src/components/MapView.tsx
@@ -2,16 +2,8 @@ import { MapContainer, TileLayer, Marker, Popup, useMap } from 'react-leaflet'
 import 'leaflet/dist/leaflet.css'
 import * as L from 'leaflet'
 import type { Place } from '../data/places'
-import { useEffect } from 'react'
+import { useEffect, useMemo } from 'react'
 
-const icon = new L.Icon({
-  iconUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-icon.png',
-  iconSize: [25, 41],
-  iconAnchor: [12, 41],
-  popupAnchor: [1, -34],
-  shadowUrl: 'https://unpkg.com/leaflet@1.9.4/dist/images/marker-shadow.png',
-  shadowSize: [41, 41],
-})
 
 interface MapViewProps {
   places: Place[]
@@ -29,6 +21,26 @@ const FlyToMarker: React.FC<{ position: L.LatLngExpression }> = ({ position }) =
 
 export const MapView: React.FC<MapViewProps> = ({ places, selectedId, onSelect }) => {
   const selectedPlace = places.find((p) => p.id === selectedId)
+  const colorMap = useMemo(() => {
+    const map = new Map<number, string>()
+    places.forEach((p) => {
+      const color = `#${Math.floor(Math.random() * 0xffffff)
+        .toString(16)
+        .padStart(6, '0')}`
+      map.set(p.id, color)
+    })
+    return map
+  }, [places])
+
+  const getIcon = (id: number) =>
+    L.divIcon({
+      html: `<div class="pizza-icon${
+        id === selectedId ? ' selected' : ''
+      }" style="background:${colorMap.get(id)}">🍕</div>`,
+      className: '' as string,
+      iconSize: [32, 32],
+      iconAnchor: [16, 16],
+    })
   return (
     <MapContainer center={[20, 0] as L.LatLngExpression} zoom={2} style={{ height: '100%', width: '100%' }}>
       <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" attribution="&copy; OpenStreetMap contributors" />
@@ -36,7 +48,7 @@ export const MapView: React.FC<MapViewProps> = ({ places, selectedId, onSelect }
         <Marker
           key={place.id}
           position={[place.lat, place.lng] as L.LatLngExpression}
-          icon={icon}
+          icon={getIcon(place.id)}
           eventHandlers={{ click: () => onSelect(place.id) }}
         >
           <Popup>

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -18,9 +18,10 @@ const Wrapper = styled.div`
 `
 
 const ListItem = styled.div<{ active: boolean }>`
-  padding: 0.5rem 0;
-  border-bottom: 1px solid #ddd;
   cursor: pointer;
+  &.sidebar-card {
+    padding: 0.5rem;
+  }
   background: ${({ active }) => (active ? '#f0f0f0' : 'transparent')};
 `
 
@@ -68,12 +69,14 @@ export const Sidebar: React.FC<SidebarProps> = ({ places, selectedId, onSelect, 
       {filtered.map((place) => (
         <ListItem
           key={place.id}
+          className={`sidebar-card${place.id === selectedId ? ' active' : ''}`}
           ref={(el: HTMLDivElement | null) => {
             refs.current[place.id] = el
           }}
           active={place.id === selectedId}
           onClick={() => onSelect(place.id)}
         >
+          <span role="img" aria-label="pizza">🍕</span>{' '}
           <strong>{place.name}</strong>
           <br />
           {place.city}, {place.country}

--- a/src/index.css
+++ b/src/index.css
@@ -6,3 +6,41 @@ body {
 #root {
   height: 100vh;
 }
+
+.sidebar-card {
+  background: white;
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin-bottom: 0.5rem;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+  transition: transform 0.2s, box-shadow 0.2s;
+}
+
+.sidebar-card:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
+}
+
+.sidebar-card.active {
+  background: #f0f0f0;
+}
+
+.pizza-icon {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  border-radius: 50%;
+  width: 32px;
+  height: 32px;
+  transform: translate(-16px, -16px);
+  font-size: 20px;
+  transition: transform 0.2s;
+}
+
+.pizza-icon:hover {
+  transform: translate(-16px, -16px) scale(1.2);
+}
+
+.pizza-icon.selected {
+  transform: translate(-16px, -16px) scale(1.3);
+}


### PR DESCRIPTION
## Summary
- restyle sidebar items as animated cards with a 🍕 prefix
- add global styles for cards and pizza map icons
- make map markers random colored pizza emojis

## Testing
- `npm run lint`
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68400da0c83c8326bf862b1ecd7eef07