### PR TITLE
Fix duplicate card and add restaurant images

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,7 +4,6 @@ import { places } from './data/places'
 import { MapView } from './components/MapView'
 import { Sidebar } from './components/Sidebar'
 import { PlaceModal } from './components/PlaceModal'
-import { PlaceCard } from './components/PlaceCard'
 import { SuggestModal } from './components/SuggestModal'
 
 const Container = styled.div`
@@ -42,12 +41,6 @@ function App() {
       />
       <div style={{ flex: 1 }}>
         <MapView places={list} selectedId={selectedId} onSelect={handleSelect} />
-        {selectedId && (
-          <PlaceCard
-            place={places.find((p) => p.id === selectedId)!}
-            onClose={() => setSelectedId(null)}
-          />
-        )}
       </div>
       {selectedPlace && (
         <PlaceModal

--- a/src/components/PlaceModal.tsx
+++ b/src/components/PlaceModal.tsx
@@ -23,6 +23,21 @@ const ModalBox = styled.div`
   max-width: 400px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.3);
   text-align: center;
+  position: relative;
+`
+
+const Image = styled.img`
+  width: 100%;
+  height: 160px;
+  object-fit: cover;
+  border-radius: 4px;
+  margin-bottom: 1rem;
+`
+
+const Stars = styled.div`
+  color: #fbbc04;
+  margin-bottom: 0.5rem;
+  font-size: 1.2rem;
 `
 
 const CloseButton = styled.button`
@@ -45,11 +60,14 @@ export const PlaceModal: React.FC<PlaceModalProps> = ({ place, onClose }: PlaceM
     <Overlay onClick={onClose}>
       <ModalBox onClick={(e: React.MouseEvent<HTMLDivElement>) => e.stopPropagation()}>
         <CloseButton onClick={onClose} aria-label="Close">&times;</CloseButton>
+        {place.image && <Image src={place.image} alt={place.name} />}
         <h2>{place.name}</h2>
         <p>
           {place.city}, {place.country}
         </p>
-        <p>Rating: {place.rating}/5</p>
+        <Stars>
+          {'\u2605'.repeat(place.rating)}{'\u2606'.repeat(5 - place.rating)}
+        </Stars>
         <p>{place.review}</p>
       </ModalBox>
     </Overlay>

--- a/src/data/places.ts
+++ b/src/data/places.ts
@@ -20,7 +20,7 @@ export const places: Place[] = [
     lng: 98.9853,
     review: 'Cozy spot with thin crust perfection.',
     rating: 4,
-    image: 'https://picsum.photos/seed/pizza1/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=1',
   },
   {
     id: 2,
@@ -31,7 +31,7 @@ export const places: Place[] = [
     lng: 126.9780,
     review: 'Creative toppings and great atmosphere.',
     rating: 5,
-    image: 'https://picsum.photos/seed/pizza2/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=2',
   },
   {
     id: 3,
@@ -42,7 +42,7 @@ export const places: Place[] = [
     lng: 14.2681,
     review: 'Authentic Neapolitan pies straight from the oven.',
     rating: 5,
-    image: 'https://picsum.photos/seed/pizza3/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=3',
   },
   {
     id: 4,
@@ -53,7 +53,7 @@ export const places: Place[] = [
     lng: 139.6917,
     review: 'Fusion-style slices with a local twist.',
     rating: 4,
-    image: 'https://picsum.photos/seed/pizza4/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=4',
   },
   {
     id: 5,
@@ -64,7 +64,7 @@ export const places: Place[] = [
     lng: 13.405,
     review: 'Late-night favorite with crispy bases.',
     rating: 3,
-    image: 'https://picsum.photos/seed/pizza5/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=5',
   },
   {
     id: 6,
@@ -75,7 +75,7 @@ export const places: Place[] = [
     lng: -74.006,
     review: 'Classic New York slices done right.',
     rating: 4,
-    image: 'https://picsum.photos/seed/pizza6/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=6',
   },
   {
     id: 7,
@@ -86,7 +86,7 @@ export const places: Place[] = [
     lng: 144.9631,
     review: 'Laid-back spot with rich flavors.',
     rating: 4,
-    image: 'https://picsum.photos/seed/pizza7/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=7',
   },
   {
     id: 8,
@@ -97,7 +97,7 @@ export const places: Place[] = [
     lng: -43.1729,
     review: 'Beachside pizza with tropical vibes.',
     rating: 3,
-    image: 'https://picsum.photos/seed/pizza8/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=8',
   },
   {
     id: 9,
@@ -108,7 +108,7 @@ export const places: Place[] = [
     lng: 2.3522,
     review: 'Charming bistro serving gourmet slices.',
     rating: 5,
-    image: 'https://picsum.photos/seed/pizza9/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=9',
   },
   {
     id: 10,
@@ -119,6 +119,6 @@ export const places: Place[] = [
     lng: -79.3832,
     review: 'Modern take on traditional pizza.',
     rating: 4,
-    image: 'https://picsum.photos/seed/pizza10/400/300',
+    image: 'https://source.unsplash.com/400x300/?italian,restaurant&sig=10',
   },
 ]


### PR DESCRIPTION
## Summary
- show only the centered modal when selecting a place
- add star display inside modal
- update example images to Italian restaurant photos

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684017dcd26c8326a5bef99e9782dcde